### PR TITLE
Fix posts search decode

### DIFF
--- a/SearchResultsView.swift
+++ b/SearchResultsView.swift
@@ -101,13 +101,13 @@ struct SearchResultsView: View {
 
             let decoder = JSONDecoder()
             decoder.dateDecodingStrategy = .iso8601
-            posts = response.hits.compactMap { hit in
-                guard let data = try? JSONSerialization.data(withJSONObject: hit, options: []) else { return nil }
-                guard var post = try? decoder.decode(Post.self, from: data) else { return nil }
+            posts = response.hits.reduce(into: [Post]()) { result, hit in
+                guard let data = try? JSONSerialization.data(withJSONObject: hit, options: []) else { return }
+                guard var post = try? decoder.decode(Post.self, from: data) else { return }
                 if let id = hit["objectID"] as? String {
                     post.objectID = id
                 }
-                return post
+                result.append(post)
             }
 
         } catch {


### PR DESCRIPTION
## Summary
- fix decoding of Algolia search results when searching posts

## Testing
- `swiftc SearchResultsView.swift -emit-module -o /tmp/SearchResultsView.swiftmodule` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_687b215ff068832d9417292844010a51