### PR TITLE
Fix hashtag search fallback

### DIFF
--- a/NetworkService+HashtagSearch.swift
+++ b/NetworkService+HashtagSearch.swift
@@ -1,0 +1,22 @@
+//
+//  NetworkService+HashtagSearch.swift
+//  FitSpo
+//
+//  Simple Firestore hashtag search used as a fallback when Algolia is
+//  unavailable.
+//
+import FirebaseFirestore
+
+extension NetworkService {
+    /// Returns up to `limit` posts whose `hashtags` array contains the given tag.
+    func searchPosts(hashtag raw: String, limit: Int = 40) async throws -> [Post] {
+        let tag = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !tag.isEmpty else { return [] }
+        let snap = try await db.collection("posts")
+            .whereField("hashtags", arrayContains: tag)
+            .order(by: "likes", descending: true)
+            .limit(to: limit)
+            .getDocuments()
+        return snap.documents.compactMap { Self.decodePost(doc: $0) }
+    }
+}

--- a/SearchResultsView.swift
+++ b/SearchResultsView.swift
@@ -142,9 +142,21 @@ struct SearchResultsView: View {
             }
 
             posts.sort { $0.likes > $1.likes }
+
+            // Fallback to Firestore if Algolia returns no hits
+            if posts.isEmpty {
+                posts = try await NetworkService.shared
+                    .searchPosts(hashtag: tag)
+            }
         } catch {
             print("Algolia search error:", error.localizedDescription)
-            posts = []
+            do {
+                posts = try await NetworkService.shared
+                    .searchPosts(hashtag: tag)
+            } catch {
+                print("Firestore hashtag search error:", error.localizedDescription)
+                posts = []
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- add Firestore hashtag search helper
- use Firestore hashtag search if Algolia search returns no results

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880586e3df4832da7b9a237cf7f515f