### PR TITLE
Remove Algolia integration

### DIFF
--- a/NetworkService+HashtagSearch.swift
+++ b/NetworkService+HashtagSearch.swift
@@ -1,0 +1,27 @@
+//
+//  NetworkService+HashtagSearch.swift
+//  FitSpo
+//
+//  Simple Firestore hashtag search used as a fallback when Algolia is
+//  unavailable.
+//
+import FirebaseFirestore
+
+extension NetworkService {
+    /// Returns up to `limit` posts whose `hashtags` array contains the given tag.
+    /// Results are sorted by like count on the client to avoid requiring a
+    /// Firestore composite index.
+    func searchPosts(hashtag raw: String, limit: Int = 40) async throws -> [Post] {
+        let tag = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !tag.isEmpty else { return [] }
+
+        let snap = try await db.collection("posts")
+            .whereField("hashtags", arrayContains: tag)
+            .limit(to: limit)
+            .getDocuments()
+
+        var posts = snap.documents.compactMap { Self.decodePost(doc: $0) }
+        posts.sort { $0.likes > $1.likes }
+        return posts
+    }
+}

--- a/NetworkService.swift
+++ b/NetworkService.swift
@@ -398,7 +398,7 @@ final class NetworkService {
     }
 
     // decode Firestore → Post
-    fileprivate static func decodePost(doc: QueryDocumentSnapshot) -> Post? {
+    static func decodePost(doc: QueryDocumentSnapshot) -> Post? {
         let d = doc.data()
         guard
             let uid     = d["userId"]    as? String,

--- a/Post.swift
+++ b/Post.swift
@@ -32,8 +32,6 @@ struct Post: Identifiable, Codable {
     // hashtags
     var hashtags: [String]
 
-    /// Optional Algolia object identifier
-    var objectID: String? = nil
 
     // convenience
     var coordinate: CLLocationCoordinate2D? {
@@ -86,6 +84,6 @@ struct Post: Identifiable, Codable {
     enum CodingKeys: String, CodingKey {
         case id, userId, imageURL, caption, username, timestamp, likes, isLiked
         case latitude, longitude, temp, weatherIcon, hashtags
-        case outfitItems, outfitTags, objectID
+        case outfitItems, outfitTags
     }
 }

--- a/SearchResultsView.swift
+++ b/SearchResultsView.swift
@@ -4,7 +4,7 @@
 import Foundation
 
 import SwiftUI
-import AlgoliaSearchClient            // v8+ of the Swift API client
+// Algolia removed – searches now use Firestore only
 
 /// Stand‑alone screen shown when user taps a username / hashtag result.
 struct SearchResultsView: View {
@@ -72,78 +72,16 @@ struct SearchResultsView: View {
         } else if query.first == "#" {
             await searchHashtag(String(query.dropFirst()))
         } else {
-            await searchPosts()
-        }
-    }
-
-    // MARK: –‑ Posts search (Algolia)
-    @MainActor
-    private func searchPosts() async {
-        do {
-            // Initialise the client *once*; credentials are already public in the repo
-            let client = SearchClient(appID: "6WFE31B7U3",
-                                      apiKey: "2b7e223b3ca3c31fc6aaea704b80ca8c")
-            let index  = client.index(withName: "posts")
-
-            // Perform the search and decode results manually. Removing the
-            // `SearchResponse<Post>` generic resolves the build error on older
-            // versions of Algolia's Swift SDK.
-            let response = try await index.search(
-                query: Query(query).set(\.hitsPerPage, to: 40)
-            )
-
-            let decoder = JSONDecoder()
-            decoder.dateDecodingStrategy = .iso8601
-            posts = response.hits.reduce(into: [Post]()) { result, hit in
-                // `Hit` from Algolia's Swift client stores record fields in
-                // `additionalProperties`. Encoding the hit back to JSON gives us
-                // a dictionary we can decode into `Post` without relying on
-                // subscripting support, which may be missing on older
-                // versions of the client.
-                guard let hitData = try? JSONEncoder().encode(hit) else { return }
-                guard var post = try? decoder.decode(Post.self, from: hitData) else { return }
-                // Extract the object identifier from the hit using reflection
-                let mirror = Mirror(reflecting: hit)
-                if let id = mirror.children.first(where: { $0.label == "objectID" })?.value as? String {
-                    post.objectID = id
-                }
-                result.append(post)
-            }
-
-        } catch {
-            print("Algolia search error:", error.localizedDescription)
-            posts = []
+            await searchHashtag(query)
         }
     }
 
     @MainActor
     private func searchHashtag(_ tag: String) async {
         do {
-            let client = SearchClient(appID: "6WFE31B7U3",
-                                      apiKey: "2b7e223b3ca3c31fc6aaea704b80ca8c")
-            let index = client.index(withName: "posts")
-
-            let q = Query("")
-                .set(\.filters, to: "hashtags:\(tag.lowercased())")
-                .set(\.hitsPerPage, to: 40)
-
-            let response = try await index.search(query: q)
-
-            let decoder = JSONDecoder()
-            decoder.dateDecodingStrategy = .iso8601
-            posts = response.hits.reduce(into: [Post]()) { result, hit in
-                guard let data = try? JSONEncoder().encode(hit),
-                      var post = try? decoder.decode(Post.self, from: data) else { return }
-                let mirror = Mirror(reflecting: hit)
-                if let id = mirror.children.first(where: { $0.label == "objectID" })?.value as? String {
-                    post.objectID = id
-                }
-                result.append(post)
-            }
-
-            posts.sort { $0.likes > $1.likes }
+            posts = try await NetworkService.shared.searchPosts(hashtag: tag)
         } catch {
-            print("Algolia search error:", error.localizedDescription)
+            print("Hashtag search error:", error.localizedDescription)
             posts = []
         }
     }


### PR DESCRIPTION
## Summary
- drop Algolia from search results view
- implement Firestore-only hashtag search that sorts on the client
- remove unused `objectID` field from Post model

## Testing
- `swiftc -parse SearchResultsView.swift`
- `swiftc -parse NetworkService+HashtagSearch.swift`
- `swiftc -parse Post.swift`


------
https://chatgpt.com/codex/tasks/task_e_6880586e3df4832da7b9a237cf7f515f